### PR TITLE
fix graphviz version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
               "requests~=2.21.0",
               "panel~=0.8.1",
               "param~=1.9.3",
-              "graphviz~=0.13",
+              "graphviz~=0.13.2",
               "pandas~=1.0.5",
               "pyjanitor~=0.20.2",
           ],


### PR DESCRIPTION
fixes #31

Error was caused by graphviz being updated to 0.20.

Fixed the version to 0.13.x and everything seems to work.

(Disregard my last comment in #31 about versions, where I didn't fully reload the app before testing).