### PR TITLE
Update aiida 2.0->2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 
 # Install recent nodejs for bokeh & jsmol-bokeh-extension
 # See https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,10 @@ RUN ln -s /app/jmol-14.29.22/jsmol ./detail/static/jsmol
 RUN ln -s /app/jmol-14.29.22/jsmol ./details/static/jsmol
 COPY setup.py ./
 RUN pip install -e .
+# NOTE This container requires graphviz~=0.13.2 that conflicts with aiida-core
+# Just force-install this version and hope nothing breaks...
+RUN pip install graphviz~=0.13.2
+
 COPY serve-app.sh /opt/
 
 # start bokeh server

--- a/pipeline_config/__init__.py
+++ b/pipeline_config/__init__.py
@@ -31,7 +31,7 @@ def update_config():
             profile_name, {
                 "default_user_email": os.getenv("default_user_email"),
                 "storage": {
-                    "backend": "psql_dos",
+                    "backend": "core.psql_dos",
                     "config": {
                         "database_engine": os.getenv("AIIDADB_ENGINE"),
                         "database_hostname": os.getenv("AIIDADB_HOST"),

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
           classifiers=["Programming Language :: Python"],
           version="1.0.0",
           install_requires=[
-              "aiida-core~=2.3",
+              "aiida-core~=2.4",
               "bokeh~=1.4.0",
               "jsmol-bokeh-extension~=0.2.1",
               "requests~=2.21.0",

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ if __name__ == '__main__':
               "pyjanitor~=0.20.2",
               "jinja2~=3.0.0",
               "frozendict~=2.3.2",
+              "numpy~=1.23.1",
           ],
           extras_require={"pre-commit": ["pre-commit==1.17.0", "prospector==1.2.0", "pylint==2.4.0"]})

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
               "requests~=2.21.0",
               "panel~=0.8.1",
               "param~=1.9.3",
-              "pandas~=1.0.5",
+              "pandas~=1.1.0",
               "pyjanitor~=0.20.2",
               "jinja2~=3.0.0",
               "frozendict~=2.3.2",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
           classifiers=["Programming Language :: Python"],
           version="1.0.0",
           install_requires=[
-              "aiida-core~=2.0",
+              "aiida-core~=2.3",
               "bokeh~=1.4.0",
               "jsmol-bokeh-extension~=0.2.1",
               "requests~=2.21.0",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ if __name__ == '__main__':
               "requests~=2.21.0",
               "panel~=0.8.1",
               "param~=1.9.3",
-              "graphviz~=0.13.2",
               "pandas~=1.0.5",
               "pyjanitor~=0.20.2",
               "jinja2~=3.0.0",


### PR DESCRIPTION
As i upgraded AiiDA on Materials Cloud to v2.4 and the storage backend upgraded as well, this container needed to be compatible.

Additionally a conflict with graphviz came up (aiida-core uses 0.20 and this repo uses 0.13). I just force install the version in the dockerfile and ignore aiida-core requirement. Everything seems to work like this.